### PR TITLE
Fix input json schema validity

### DIFF
--- a/api/api_geo_process_v1.0.yaml
+++ b/api/api_geo_process_v1.0.yaml
@@ -184,7 +184,7 @@ paths:
         variables:
           customPath:
             default: ''
-    parameters: 
+    parameters:
       - name: jobId
         in: path
         description: Job identifier
@@ -212,7 +212,7 @@ paths:
         variables:
           customPath:
             default: ''
-    parameters: 
+    parameters:
       - name: jobId
         in: path
         description: Job identifier
@@ -250,7 +250,7 @@ paths:
         variables:
           customPath:
             default: ''
-    parameters: 
+    parameters:
       - name: jobId
         in: path
         description: Job identifier
@@ -302,7 +302,7 @@ paths:
         variables:
           customPath:
             default: ''
-    parameters: 
+    parameters:
       - name: jobId
         in: path
         description: Job identifier.
@@ -630,7 +630,7 @@ components:
                 "tile": {
                   "description": "The tile image base64 encoded, may be JPEG or PNG format",
                   "type": "string",
-                  "format": "base64"
+                  "contentEncoding": "base64"
                 }
               }
             }
@@ -709,7 +709,7 @@ components:
             (MIME type) and value as object (json schema) or string (description)
             for contents that do not need an extra definition (as for image/jpeg
             or application/geo+json).
-            
+
             If a content is of type JSON (key as application/json) the value might
             be a JSON Schema object with ADS metadata extensions.
           type: object
@@ -957,4 +957,3 @@ components:
         timestamp:
           description: Error timestamp.
           type: string
-

--- a/api/api_geo_processes_manager_v1.0.yaml
+++ b/api/api_geo_processes_manager_v1.0.yaml
@@ -12,7 +12,7 @@ info:
     operating processes.
 
     A job is a unitary execution of a process.
-    
+
     A process may be an unitary processing or a composition of several tasks.
     In the later case, the tasks workflow management can be specific to the process
     or delegated to the process manager which is also specific to the geo process
@@ -66,7 +66,7 @@ paths:
       responses:
         '200':
           description: Process Open API web UI.
-  
+
   #
   # Process list and creation
   #
@@ -189,7 +189,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  
+
   #
   # Process management
   #
@@ -344,7 +344,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  
+
   #
   # Job list for all processes
   #
@@ -392,7 +392,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  
+
   #
   # Job list and creation for one process
   #
@@ -527,7 +527,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/Input'
-  
+
   #
   # Job management
   #
@@ -640,7 +640,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  
+
   #
   # Job technical metadata
   #
@@ -696,7 +696,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  
+
   #
   # Job task list
   #
@@ -770,7 +770,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  
+
   #
   # Job task informations
   #
@@ -1221,7 +1221,7 @@ components:
             "tile": {
               "description": "The tile image base64 encoded, may be JPEG or PNG format",
               "type": "string",
-              "format": "base64"
+              "contentEncoding": "base64"
             }
           }
         }


### PR DESCRIPTION
Since `base64` is not a valid format according to JSON schema specifications : 
http://json-schema.org/latest/json-schema-validation.html#rfc.section.7.3

... we should use `contentEncoding` instead : 
http://json-schema.org/latest/json-schema-validation.html#rfc.section.8.3